### PR TITLE
fixed reference error in isTextShapeInvalid method

### DIFF
--- a/javascript/mxClient.js
+++ b/javascript/mxClient.js
@@ -48787,7 +48787,9 @@ mxCellRenderer.prototype.redrawLabel = function(state, forced)
 mxCellRenderer.prototype.isTextShapeInvalid = function(state, shape)
 {
 	function check(property, stylename, defaultValue)
-	{
+	{		
+		var result;
+		
 		// Workaround for spacing added to directional spacing
 		if (stylename == 'spacingTop' || stylename == 'spacingRight' ||
 			stylename == 'spacingBottom' || stylename == 'spacingLeft')

--- a/javascript/src/js/view/mxCellRenderer.js
+++ b/javascript/src/js/view/mxCellRenderer.js
@@ -978,6 +978,8 @@ mxCellRenderer.prototype.isTextShapeInvalid = function(state, shape)
 {
 	function check(property, stylename, defaultValue)
 	{
+		var result;
+		
 		// Workaround for spacing added to directional spacing
 		if (stylename == 'spacingTop' || stylename == 'spacingRight' ||
 			stylename == 'spacingBottom' || stylename == 'spacingLeft')


### PR DESCRIPTION
Hello, I've found a crash when I tried to enable html labels in my graph via graph.setHtmlLabels(true).
The error is in mxCellRenderer.prototype.isTextShapeInvalid method, result variable is not defined in check function, which leads to ReferenceError in strict mode.
See screenshot attached below:
![image](https://user-images.githubusercontent.com/8245429/57148131-a8da9300-6dd1-11e9-859e-f9ddbae66eb4.png)

Thanks!